### PR TITLE
Create Postgres 15 docker images

### DIFF
--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -96,7 +96,7 @@ RUN set -ex; \
 	dpkgArch="$(dpkg --print-architecture)"; \
 	aptRepo="[ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main $PG_MAJOR"; \
 	case "$dpkgArch" in \
-		amd64 | arm64 | ppc64el) \
+		i386 | amd64 | arm64 | ppc64el) \
 # arches officialy built by upstream
 			echo "deb $aptRepo" > /etc/apt/sources.list.d/pgdg.list; \
 			apt-get update; \

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -1,5 +1,5 @@
 #
-# Custom PostgreSQL 15.1 image for Debian Bookworm (12)
+# Custom PostgreSQL 15.2 image for Debian Bookworm (12)
 # Based on https://github.com/docker-library/postgres/blob/74e51d102aede317665f2b4a9b89362135402fe7/11/stretch/Dockerfile
 #
 
@@ -86,7 +86,7 @@ RUN set -ex; \
 ENV PG_MAJOR 15
 ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
 
-ENV PG_VERSION 15.1-1+b1
+ENV PG_VERSION 15.2-2
 
 RUN set -ex; \
 	\

--- a/15/bookworm/Dockerfile
+++ b/15/bookworm/Dockerfile
@@ -1,0 +1,221 @@
+#
+# Custom PostgreSQL 15.1 image for Debian Bookworm (12)
+# Based on https://github.com/docker-library/postgres/blob/74e51d102aede317665f2b4a9b89362135402fe7/11/stretch/Dockerfile
+#
+
+FROM debian:bookworm-slim
+
+RUN set -ex; \
+	if ! command -v gpg > /dev/null; then \
+		apt-get update; \
+		apt-get install -y --no-install-recommends \
+			gnupg \
+			dirmngr \
+		; \
+		rm -rf /var/lib/apt/lists/*; \
+	fi
+
+# explicitly set user/group IDs
+RUN set -eux; \
+	groupadd -r postgres --gid=999; \
+# https://salsa.debian.org/postgresql/postgresql-common/blob/997d842ee744687d99a2b2d95c1083a2615c79e8/debian/postgresql-common.postinst#L32-35
+	useradd -r -g postgres --uid=999 --home-dir=/var/lib/postgresql --shell=/bin/bash postgres; \
+# also create the postgres user's home directory with appropriate permissions
+# see https://github.com/docker-library/postgres/issues/274
+	mkdir -p /var/lib/postgresql; \
+	chown -R postgres:postgres /var/lib/postgresql
+
+# grab gosu for easy step-down from root
+# https://github.com/tianon/gosu/releases
+ENV GOSU_VERSION 1.14
+RUN set -eux; \
+	savedAptMark="$(apt-mark showmanual)"; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends ca-certificates wget; \
+	rm -rf /var/lib/apt/lists/*; \
+	dpkgArch="$(dpkg --print-architecture | awk -F- '{ print $NF }')"; \
+	wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch"; \
+	wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc"; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4; \
+	gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu; \
+	gpgconf --kill all; \
+	rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc; \
+	apt-mark auto '.*' > /dev/null; \
+	[ -z "$savedAptMark" ] || apt-mark manual $savedAptMark > /dev/null; \
+	apt-get purge -y --auto-remove -o APT::AutoRemove::RecommendsImportant=false; \
+	chmod +x /usr/local/bin/gosu; \
+	gosu --version; \
+	gosu nobody true
+
+# make the "en_US.UTF-8" locale so postgres will be utf-8 enabled by default
+RUN set -eux; \
+	if [ -f /etc/dpkg/dpkg.cfg.d/docker ]; then \
+# if this file exists, we're likely in "debian:xxx-slim", and locales are thus being excluded so we need to remove that exclusion (since we need locales)
+		grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
+		sed -ri '/\/usr\/share\/locale/d' /etc/dpkg/dpkg.cfg.d/docker; \
+		! grep -q '/usr/share/locale' /etc/dpkg/dpkg.cfg.d/docker; \
+	fi; \
+	apt-get update; apt-get install -y --no-install-recommends locales; rm -rf /var/lib/apt/lists/*; \
+	localedef -i en_US -c -f UTF-8 -A /usr/share/locale/locale.alias en_US.UTF-8
+ENV LANG en_US.utf8
+
+RUN set -eux; \
+	apt-get update; \
+	apt-get install -y --no-install-recommends \
+		libnss-wrapper \
+		xz-utils \
+		zstd \
+	; \
+	rm -rf /var/lib/apt/lists/*
+
+RUN mkdir /docker-entrypoint-initdb.d
+
+RUN set -ex; \
+# pub   4096R/ACCC4CF8 2011-10-13 [expires: 2019-07-02]
+#       Key fingerprint = B97B 0AFC AA1A 47F0 44F2  44A0 7FCC 7D46 ACCC 4CF8
+# uid                  PostgreSQL Debian Repository
+	key='B97B0AFCAA1A47F044F244A07FCC7D46ACCC4CF8'; \
+	export GNUPGHOME="$(mktemp -d)"; \
+	mkdir -p /usr/local/share/keyrings/; \
+	gpg --batch --keyserver keyserver.ubuntu.com --recv-keys "$key"; \
+	gpg --batch --export --armor "$key" > /usr/local/share/keyrings/postgres.gpg.asc; \
+	command -v gpgconf > /dev/null && gpgconf --kill all; \
+	rm -rf "$GNUPGHOME"
+
+ENV PG_MAJOR 15
+ENV PATH $PATH:/usr/lib/postgresql/$PG_MAJOR/bin
+
+ENV PG_VERSION 15.1-1+b1
+
+RUN set -ex; \
+	\
+# see note below about "*.pyc" files
+	export PYTHONDONTWRITEBYTECODE=1; \
+	\
+	dpkgArch="$(dpkg --print-architecture)"; \
+	aptRepo="[ signed-by=/usr/local/share/keyrings/postgres.gpg.asc ] http://apt.postgresql.org/pub/repos/apt/ bookworm-pgdg main $PG_MAJOR"; \
+	case "$dpkgArch" in \
+		amd64 | arm64 | ppc64el) \
+# arches officialy built by upstream
+			echo "deb $aptRepo" > /etc/apt/sources.list.d/pgdg.list; \
+			apt-get update; \
+			;; \
+		*) \
+# we're on an architecture upstream doesn't officially build for
+# let's build binaries from their published source packages
+			echo "deb-src $aptRepo" > /etc/apt/sources.list.d/pgdg.list; \
+			\
+			savedAptMark="$(apt-mark showmanual)"; \
+			\
+			tempDir="$(mktemp -d)"; \
+			cd "$tempDir"; \
+			\
+# create a temporary local APT repo to install from (so that dependency resolution can be handled by APT, as it should be)
+			apt-get update; \
+			apt-get install -y --no-install-recommends dpkg-dev; \
+			echo "deb [ trusted=yes ] file://$tempDir ./" > /etc/apt/sources.list.d/temp.list; \
+			_update_repo() { \
+				dpkg-scanpackages . > Packages; \
+# work around the following APT issue by using "Acquire::GzipIndexes=false" (overriding "/etc/apt/apt.conf.d/docker-gzip-indexes")
+#   Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+#   ...
+#   E: Failed to fetch store:/var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages  Could not open file /var/lib/apt/lists/partial/_tmp_tmp.ODWljpQfkE_._Packages - open (13: Permission denied)
+				apt-get -o Acquire::GzipIndexes=false update; \
+			}; \
+			_update_repo; \
+			\
+# build .deb files from upstream's source packages (which are verified by apt-get)
+			nproc="$(nproc)"; \
+			export DEB_BUILD_OPTIONS="nocheck parallel=$nproc"; \
+# we have to build postgresql-common first because postgresql-$PG_MAJOR shares "debian/rules" logic with it: https://salsa.debian.org/postgresql/postgresql/-/commit/99f44476e258cae6bf9e919219fa2c5414fa2876
+# (and it "Depends: pgdg-keyring")
+			apt-get build-dep -y postgresql-common pgdg-keyring; \
+			apt-get source --compile postgresql-common pgdg-keyring; \
+			_update_repo; \
+			apt-get build-dep -y "postgresql-$PG_MAJOR=$PG_VERSION"; \
+			apt-get source --compile "postgresql-$PG_MAJOR=$PG_VERSION"; \
+			\
+# we don't remove APT lists here because they get re-downloaded and removed later
+			\
+# reset apt-mark's "manual" list so that "purge --auto-remove" will remove all build dependencies
+# (which is done after we install the built packages so we don't have to redownload any overlapping dependencies)
+			apt-mark showmanual | xargs apt-mark auto > /dev/null; \
+			apt-mark manual $savedAptMark; \
+			\
+			ls -lAFh; \
+			_update_repo; \
+			grep '^Package: ' Packages; \
+			cd /; \
+			;; \
+	esac; \
+	\
+	apt-get install -y --no-install-recommends postgresql-common; \
+	sed -ri 's/#(create_main_cluster) .*$/\1 = false/' /etc/postgresql-common/createcluster.conf; \
+	apt-get install -y --no-install-recommends \
+		"postgresql-$PG_MAJOR=$PG_VERSION" \
+	; \
+	\
+	rm -rf /var/lib/apt/lists/*; \
+	\
+	if [ -n "$tempDir" ]; then \
+# if we have leftovers from building, let's purge them (including extra, unnecessary build deps)
+		apt-get purge -y --auto-remove; \
+		rm -rf "$tempDir" /etc/apt/sources.list.d/temp.list; \
+	fi; \
+	\
+# some of the steps above generate a lot of "*.pyc" files (and setting "PYTHONDONTWRITEBYTECODE" beforehand doesn't propagate properly for some reason), so we clean them up manually (as long as they aren't owned by a package)
+	find /usr -name '*.pyc' -type f -exec bash -c 'for pyc; do dpkg -S "$pyc" &> /dev/null || rm -vf "$pyc"; done' -- '{}' +; \
+	\
+	postgres --version
+
+# make the sample config easier to munge (and "correct by default")
+RUN set -eux; \
+	dpkg-divert --add --rename --divert "/usr/share/postgresql/postgresql.conf.sample.dpkg" "/usr/share/postgresql/$PG_MAJOR/postgresql.conf.sample"; \
+	cp -v /usr/share/postgresql/postgresql.conf.sample.dpkg /usr/share/postgresql/postgresql.conf.sample; \
+	ln -sv ../postgresql.conf.sample "/usr/share/postgresql/$PG_MAJOR/"; \
+	sed -ri "s!^#?(listen_addresses)\s*=\s*\S+.*!\1 = '*'!" /usr/share/postgresql/postgresql.conf.sample; \
+	grep -F "listen_addresses = '*'" /usr/share/postgresql/postgresql.conf.sample
+
+RUN mkdir -p /var/run/postgresql && chown -R postgres:postgres /var/run/postgresql && chmod 2777 /var/run/postgresql
+
+ENV PGDATA /var/lib/postgresql/data
+# this 777 will be replaced by 700 at runtime (allows semi-arbitrary "--user" values)
+RUN mkdir -p "$PGDATA" && chown -R postgres:postgres "$PGDATA" && chmod 777 "$PGDATA"
+VOLUME /var/lib/postgresql/data
+
+COPY docker-entrypoint.sh /usr/local/bin/
+ENTRYPOINT ["docker-entrypoint.sh"]
+
+# We set the default STOPSIGNAL to SIGINT, which corresponds to what PostgreSQL
+# calls "Fast Shutdown mode" wherein new connections are disallowed and any
+# in-progress transactions are aborted, allowing PostgreSQL to stop cleanly and
+# flush tables to disk, which is the best compromise available to avoid data
+# corruption.
+#
+# Users who know their applications do not keep open long-lived idle connections
+# may way to use a value of SIGTERM instead, which corresponds to "Smart
+# Shutdown mode" in which any existing sessions are allowed to finish and the
+# server stops when all sessions are terminated.
+#
+# See https://www.postgresql.org/docs/12/server-shutdown.html for more details
+# about available PostgreSQL server shutdown signals.
+#
+# See also https://www.postgresql.org/docs/12/server-start.html for further
+# justification of this as the default value, namely that the example (and
+# shipped) systemd service files use the "Fast Shutdown mode" for service
+# termination.
+#
+STOPSIGNAL SIGINT
+#
+# An additional setting that is recommended for all users regardless of this
+# value is the runtime "--stop-timeout" (or your orchestrator/runtime's
+# equivalent) for controlling how long to wait between sending the defined
+# STOPSIGNAL and sending SIGKILL (which is likely to cause data corruption).
+#
+# The default in most runtimes (such as Docker) is 10 seconds, and the
+# documentation at https://www.postgresql.org/docs/12/server-start.html notes
+# that even 90 seconds may not be long enough in many instances.
+
+EXPOSE 5432
+CMD ["postgres"]

--- a/15/bookworm/docker-entrypoint.sh
+++ b/15/bookworm/docker-entrypoint.sh
@@ -1,0 +1,346 @@
+#!/usr/bin/env bash
+set -Eeo pipefail
+# TODO swap to -Eeuo pipefail above (after handling all potentially-unset variables)
+
+# usage: file_env VAR [DEFAULT]
+#    ie: file_env 'XYZ_DB_PASSWORD' 'example'
+# (will allow for "$XYZ_DB_PASSWORD_FILE" to fill in the value of
+#  "$XYZ_DB_PASSWORD" from a file, especially for Docker's secrets feature)
+file_env() {
+	local var="$1"
+	local fileVar="${var}_FILE"
+	local def="${2:-}"
+	if [ "${!var:-}" ] && [ "${!fileVar:-}" ]; then
+		echo >&2 "error: both $var and $fileVar are set (but are exclusive)"
+		exit 1
+	fi
+	local val="$def"
+	if [ "${!var:-}" ]; then
+		val="${!var}"
+	elif [ "${!fileVar:-}" ]; then
+		val="$(< "${!fileVar}")"
+	fi
+	export "$var"="$val"
+	unset "$fileVar"
+}
+
+# check to see if this file is being run or sourced from another script
+_is_sourced() {
+	# https://unix.stackexchange.com/a/215279
+	[ "${#FUNCNAME[@]}" -ge 2 ] \
+		&& [ "${FUNCNAME[0]}" = '_is_sourced' ] \
+		&& [ "${FUNCNAME[1]}" = 'source' ]
+}
+
+# used to create initial postgres directories and if run as root, ensure ownership to the "postgres" user
+docker_create_db_directories() {
+	local user; user="$(id -u)"
+
+	mkdir -p "$PGDATA"
+	# ignore failure since there are cases where we can't chmod (and PostgreSQL might fail later anyhow - it's picky about permissions of this directory)
+	chmod 700 "$PGDATA" || :
+
+	# ignore failure since it will be fine when using the image provided directory; see also https://github.com/docker-library/postgres/pull/289
+	mkdir -p /var/run/postgresql || :
+	chmod 775 /var/run/postgresql || :
+
+	# Create the transaction log directory before initdb is run so the directory is owned by the correct user
+	if [ -n "${POSTGRES_INITDB_WALDIR:-}" ]; then
+		mkdir -p "$POSTGRES_INITDB_WALDIR"
+		if [ "$user" = '0' ]; then
+			find "$POSTGRES_INITDB_WALDIR" \! -user postgres -exec chown postgres '{}' +
+		fi
+		chmod 700 "$POSTGRES_INITDB_WALDIR"
+	fi
+
+	# allow the container to be started with `--user`
+	if [ "$user" = '0' ]; then
+		find "$PGDATA" \! -user postgres -exec chown postgres '{}' +
+		find /var/run/postgresql \! -user postgres -exec chown postgres '{}' +
+	fi
+}
+
+# initialize empty PGDATA directory with new database via 'initdb'
+# arguments to `initdb` can be passed via POSTGRES_INITDB_ARGS or as arguments to this function
+# `initdb` automatically creates the "postgres", "template0", and "template1" dbnames
+# this is also where the database user is created, specified by `POSTGRES_USER` env
+docker_init_database_dir() {
+	# "initdb" is particular about the current user existing in "/etc/passwd", so we use "nss_wrapper" to fake that if necessary
+	# see https://github.com/docker-library/postgres/pull/253, https://github.com/docker-library/postgres/issues/359, https://cwrap.org/nss_wrapper.html
+	local uid; uid="$(id -u)"
+	if ! getent passwd "$uid" &> /dev/null; then
+		# see if we can find a suitable "libnss_wrapper.so" (https://salsa.debian.org/sssd-team/nss-wrapper/-/commit/b9925a653a54e24d09d9b498a2d913729f7abb15)
+		local wrapper
+		for wrapper in {/usr,}/lib{/*,}/libnss_wrapper.so; do
+			if [ -s "$wrapper" ]; then
+				NSS_WRAPPER_PASSWD="$(mktemp)"
+				NSS_WRAPPER_GROUP="$(mktemp)"
+				export LD_PRELOAD="$wrapper" NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+				local gid; gid="$(id -g)"
+				echo "postgres:x:$uid:$gid:PostgreSQL:$PGDATA:/bin/false" > "$NSS_WRAPPER_PASSWD"
+				echo "postgres:x:$gid:" > "$NSS_WRAPPER_GROUP"
+				break
+			fi
+		done
+	fi
+
+	if [ -n "${POSTGRES_INITDB_WALDIR:-}" ]; then
+		set -- --waldir "$POSTGRES_INITDB_WALDIR" "$@"
+	fi
+
+	eval 'initdb --username="$POSTGRES_USER" --pwfile=<(echo "$POSTGRES_PASSWORD") '"$POSTGRES_INITDB_ARGS"' "$@"'
+
+	# unset/cleanup "nss_wrapper" bits
+	if [[ "${LD_PRELOAD:-}" == */libnss_wrapper.so ]]; then
+		rm -f "$NSS_WRAPPER_PASSWD" "$NSS_WRAPPER_GROUP"
+		unset LD_PRELOAD NSS_WRAPPER_PASSWD NSS_WRAPPER_GROUP
+	fi
+}
+
+# print large warning if POSTGRES_PASSWORD is long
+# error if both POSTGRES_PASSWORD is empty and POSTGRES_HOST_AUTH_METHOD is not 'trust'
+# print large warning if POSTGRES_HOST_AUTH_METHOD is set to 'trust'
+# assumes database is not set up, ie: [ -z "$DATABASE_ALREADY_EXISTS" ]
+docker_verify_minimum_env() {
+	# check password first so we can output the warning before postgres
+	# messes it up
+	if [ "${#POSTGRES_PASSWORD}" -ge 100 ]; then
+		cat >&2 <<-'EOWARN'
+
+			WARNING: The supplied POSTGRES_PASSWORD is 100+ characters.
+
+			  This will not work if used via PGPASSWORD with "psql".
+
+			  https://www.postgresql.org/message-id/flat/E1Rqxp2-0004Qt-PL%40wrigleys.postgresql.org (BUG #6412)
+			  https://github.com/docker-library/postgres/issues/507
+
+		EOWARN
+	fi
+	if [ -z "$POSTGRES_PASSWORD" ] && [ 'trust' != "$POSTGRES_HOST_AUTH_METHOD" ]; then
+		# The - option suppresses leading tabs but *not* spaces. :)
+		cat >&2 <<-'EOE'
+			Error: Database is uninitialized and superuser password is not specified.
+			       You must specify POSTGRES_PASSWORD to a non-empty value for the
+			       superuser. For example, "-e POSTGRES_PASSWORD=password" on "docker run".
+
+			       You may also use "POSTGRES_HOST_AUTH_METHOD=trust" to allow all
+			       connections without a password. This is *not* recommended.
+
+			       See PostgreSQL documentation about "trust":
+			       https://www.postgresql.org/docs/current/auth-trust.html
+		EOE
+		exit 1
+	fi
+	if [ 'trust' = "$POSTGRES_HOST_AUTH_METHOD" ]; then
+		cat >&2 <<-'EOWARN'
+			********************************************************************************
+			WARNING: POSTGRES_HOST_AUTH_METHOD has been set to "trust". This will allow
+			         anyone with access to the Postgres port to access your database without
+			         a password, even if POSTGRES_PASSWORD is set. See PostgreSQL
+			         documentation about "trust":
+			         https://www.postgresql.org/docs/current/auth-trust.html
+			         In Docker's default configuration, this is effectively any other
+			         container on the same system.
+
+			         It is not recommended to use POSTGRES_HOST_AUTH_METHOD=trust. Replace
+			         it with "-e POSTGRES_PASSWORD=password" instead to set a password in
+			         "docker run".
+			********************************************************************************
+		EOWARN
+	fi
+}
+
+# usage: docker_process_init_files [file [file [...]]]
+#    ie: docker_process_init_files /always-initdb.d/*
+# process initializer files, based on file extensions and permissions
+docker_process_init_files() {
+	# psql here for backwards compatibility "${psql[@]}"
+	psql=( docker_process_sql )
+
+	echo
+	local f
+	for f; do
+		case "$f" in
+			*.sh)
+				# https://github.com/docker-library/postgres/issues/450#issuecomment-393167936
+				# https://github.com/docker-library/postgres/pull/452
+				if [ -x "$f" ]; then
+					echo "$0: running $f"
+					"$f"
+				else
+					echo "$0: sourcing $f"
+					. "$f"
+				fi
+				;;
+			*.sql)     echo "$0: running $f"; docker_process_sql -f "$f"; echo ;;
+			*.sql.gz)  echo "$0: running $f"; gunzip -c "$f" | docker_process_sql; echo ;;
+			*.sql.xz)  echo "$0: running $f"; xzcat "$f" | docker_process_sql; echo ;;
+			*.sql.zst) echo "$0: running $f"; zstd -dc "$f" | docker_process_sql; echo ;;
+			*)         echo "$0: ignoring $f" ;;
+		esac
+		echo
+	done
+}
+
+# Execute sql script, passed via stdin (or -f flag of pqsl)
+# usage: docker_process_sql [psql-cli-args]
+#    ie: docker_process_sql --dbname=mydb <<<'INSERT ...'
+#    ie: docker_process_sql -f my-file.sql
+#    ie: docker_process_sql <my-file.sql
+docker_process_sql() {
+	local query_runner=( psql -v ON_ERROR_STOP=1 --username "$POSTGRES_USER" --no-password --no-psqlrc )
+	if [ -n "$POSTGRES_DB" ]; then
+		query_runner+=( --dbname "$POSTGRES_DB" )
+	fi
+
+	PGHOST= PGHOSTADDR= "${query_runner[@]}" "$@"
+}
+
+# create initial database
+# uses environment variables for input: POSTGRES_DB
+docker_setup_db() {
+	local dbAlreadyExists
+	dbAlreadyExists="$(
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" --tuples-only <<-'EOSQL'
+			SELECT 1 FROM pg_database WHERE datname = :'db' ;
+		EOSQL
+	)"
+	if [ -z "$dbAlreadyExists" ]; then
+		POSTGRES_DB= docker_process_sql --dbname postgres --set db="$POSTGRES_DB" <<-'EOSQL'
+			CREATE DATABASE :"db" ;
+		EOSQL
+		echo
+	fi
+}
+
+# Loads various settings that are used elsewhere in the script
+# This should be called before any other functions
+docker_setup_env() {
+	file_env 'POSTGRES_PASSWORD'
+
+	file_env 'POSTGRES_USER' 'postgres'
+	file_env 'POSTGRES_DB' "$POSTGRES_USER"
+	file_env 'POSTGRES_INITDB_ARGS'
+	: "${POSTGRES_HOST_AUTH_METHOD:=}"
+
+	declare -g DATABASE_ALREADY_EXISTS
+	# look specifically for PG_VERSION, as it is expected in the DB dir
+	if [ -s "$PGDATA/PG_VERSION" ]; then
+		DATABASE_ALREADY_EXISTS='true'
+	fi
+}
+
+# append POSTGRES_HOST_AUTH_METHOD to pg_hba.conf for "host" connections
+# all arguments will be passed along as arguments to `postgres` for getting the value of 'password_encryption'
+pg_setup_hba_conf() {
+	# default authentication method is md5 on versions before 14
+	# https://www.postgresql.org/about/news/postgresql-14-released-2318/
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+	local auth
+	# check the default/configured encryption and use that as the auth method
+	auth="$(postgres -C password_encryption "$@")"
+	: "${POSTGRES_HOST_AUTH_METHOD:=$auth}"
+	{
+		echo
+		if [ 'trust' = "$POSTGRES_HOST_AUTH_METHOD" ]; then
+			echo '# warning trust is enabled for all connections'
+			echo '# see https://www.postgresql.org/docs/12/auth-trust.html'
+		fi
+		echo "host all all all $POSTGRES_HOST_AUTH_METHOD"
+	} >> "$PGDATA/pg_hba.conf"
+}
+
+# start socket-only postgresql server for setting up or running scripts
+# all arguments will be passed along as arguments to `postgres` (via pg_ctl)
+docker_temp_server_start() {
+	if [ "$1" = 'postgres' ]; then
+		shift
+	fi
+
+	# internal start of server in order to allow setup using psql client
+	# does not listen on external TCP/IP and waits until start finishes
+	set -- "$@" -c listen_addresses='' -p "${PGPORT:-5432}"
+
+	PGUSER="${PGUSER:-$POSTGRES_USER}" \
+	pg_ctl -D "$PGDATA" \
+		-o "$(printf '%q ' "$@")" \
+		-w start
+}
+
+# stop postgresql server after done setting up user and running scripts
+docker_temp_server_stop() {
+	PGUSER="${PGUSER:-postgres}" \
+	pg_ctl -D "$PGDATA" -m fast -w stop
+}
+
+# check arguments for an option that would cause postgres to stop
+# return true if there is one
+_pg_want_help() {
+	local arg
+	for arg; do
+		case "$arg" in
+			# postgres --help | grep 'then exit'
+			# leaving out -C on purpose since it always fails and is unhelpful:
+			# postgres: could not access the server configuration file "/var/lib/postgresql/data/postgresql.conf": No such file or directory
+			-'?'|--help|--describe-config|-V|--version)
+				return 0
+				;;
+		esac
+	done
+	return 1
+}
+
+_main() {
+	# if first arg looks like a flag, assume we want to run postgres server
+	if [ "${1:0:1}" = '-' ]; then
+		set -- postgres "$@"
+	fi
+
+	if [ "$1" = 'postgres' ] && ! _pg_want_help "$@"; then
+		docker_setup_env
+		# setup data directories and permissions (when run as root)
+		docker_create_db_directories
+		if [ "$(id -u)" = '0' ]; then
+			# then restart script as postgres user
+			exec gosu postgres "$BASH_SOURCE" "$@"
+		fi
+
+		# only run initialization on an empty data directory
+		if [ -z "$DATABASE_ALREADY_EXISTS" ]; then
+			docker_verify_minimum_env
+
+			# check dir permissions to reduce likelihood of half-initialized database
+			ls /docker-entrypoint-initdb.d/ > /dev/null
+
+			docker_init_database_dir
+			pg_setup_hba_conf "$@"
+
+			# PGPASSWORD is required for psql when authentication is required for 'local' connections via pg_hba.conf and is otherwise harmless
+			# e.g. when '--auth=md5' or '--auth-local=md5' is used in POSTGRES_INITDB_ARGS
+			export PGPASSWORD="${PGPASSWORD:-$POSTGRES_PASSWORD}"
+			docker_temp_server_start "$@"
+
+			docker_setup_db
+			docker_process_init_files /docker-entrypoint-initdb.d/*
+
+			docker_temp_server_stop
+			unset PGPASSWORD
+
+			echo
+			echo 'PostgreSQL init process complete; ready for start up.'
+			echo
+		else
+			echo
+			echo 'PostgreSQL Database directory appears to contain a database; Skipping initialization'
+			echo
+		fi
+	fi
+
+	exec "$@"
+}
+
+if ! _is_sourced; then
+	_main "$@"
+fi

--- a/README.md
+++ b/README.md
@@ -19,11 +19,13 @@ This repository holds Dockerfiles for building custom postgres container images.
 
 ## Usage
 
-In general this repo is used to build and push multi-arch images to Docker Hub. This is done by first building the images for target architectures, in this case `linux/386`, `linux/arm64/v8`, and `linux/amd64`, then pushing them to Docker Hub. After these images are pushed to Docker Hub the images can be pulled just like any other Docker image.
+In general this repo is used to build and push multi-arch images to Docker Hub. This is done by first building the images for target architectures, in this case `linux/arm64/v8` and `linux/amd64`, then pushing them to Docker Hub. After these images are pushed to Docker Hub the images can be pulled just like any other Docker image.
 
 ### Run Script
 
 The `run` script in the root of the repository can be used to perform various Docker image management tasks. For a list of available commands run: `./run`.
+
+We are currently using the `factalinc/postgres:11.16-buster` image by default in local environments. `factalinc/postgres:15.1-bookworm` is considered experimental at this time. Using the `*_15_bookworm` verison of the commands below works the same way as noted but builds PostgreSQL 15 container images instead.
 
 #### buildx_11_buster
 

--- a/doctor
+++ b/doctor
@@ -1,0 +1,98 @@
+#!/bin/bash
+# (c) 2020 Artur.Klauser@computer.org
+# SPDX-License-Identifier: Apache-2.0 OR MIT
+#
+# This script checks if all software requirements are met in a Linux environment
+# in order to use 'docker buildx' to build multi-architecture images.
+# For more information see:
+# https://nexus.eddiesinentropy.net/2020/01/12/Building-Multi-architecture-Docker-Images-With-Buildx/
+
+function error() {
+  echo "ERROR: $*"
+  exit 1
+}
+
+function ok() {
+  echo "OK: $*"
+}
+
+function version() {
+  printf '%02d' $(echo "$1" | tr . ' ' | sed -e 's/ 0*/ /g') 2>/dev/null
+}
+
+function check_qemu_binfmt() {
+  # Docker
+  if ! command -v docker >/dev/null 2>&1; then
+    error "Can't find docker." \
+	 "Install with 'sudo apt-get install docker-ce' or docker.io."
+  fi
+  docker_version="$(docker --version | cut -d' ' -f3 | tr -cd '0-9.')"
+  if [[ "$(version "$docker_version")" < "$(version '19.03')" ]]; then
+    error "docker $docker_version too old. Need >= 19.03"
+  fi
+  docker_experimental="$(docker version | \
+                         awk '/^ *Experimental:/ {print $2 ; exit}')"
+  if [[ "$docker_experimental" != 'true' ]]; then
+    error "docker experimental flag not enabled:"\
+          "Set with 'export DOCKER_CLI_EXPERIMENTAL=enabled'"
+  else
+    ok "docker $docker_version supports buildx experimental feature."
+  fi
+
+  # Kernel
+  kernel_version="$(uname -r)"
+  if [[ "$(version "$kernel_version")" < "$(version '4.8')" ]]; then
+    error "Kernel $kernel_version too old - need >= 4.8." \
+          " Install a newer kernel."
+  else
+    ok "kernel $kernel_version has binfmt_misc fix-binary (F) support."
+  fi
+
+  # binfmt_misc file system
+  if [[ "$(mount | grep -c '/proc/sys/fs/binfmt_misc')" == '0' ]]; then
+    error '/proc/sys/fs/binfmt_misc not mounted. Mount with' \
+	  "'sudo mount -t binfmt_misc binfmt_misc /proc/sys/fs/binfmt_misc'"
+  else
+    ok "/proc/sys/fs/binfmt_misc is mounted"
+  fi
+
+  # binfmt-support
+  if ! command -v update-binfmts >/dev/null 2>&1; then
+    error "Can't find update-binfmts." \
+	 "Install with 'sudo apt-get install binfmt-support'."
+  fi
+  binfmt_version="$(update-binfmts --version | awk '{print $NF}')"
+  if [[ "$(version "$binfmt_version")" < "$(version '2.1.7')" ]]; then
+    error "update-binfmts $binfmt_version too old. Need >= 2.1.7"
+  else
+    ok "update-binfmts $binfmt_version has fix-binary (F) support."
+  fi
+
+  # QEMU
+  if [[ ! -e '/proc/sys/fs/binfmt_misc/qemu-aarch64' ]]; then
+    # Skip this test if QEMU isn't registered with binfmt_misc. It might
+    # come from a docker image rather than the host file system.
+    if [[ ! -e '/usr/bin/qemu-aarch64-static' ]]; then
+      error "Missing QEMU." \
+            " Install with 'sudo apt-get install qemu-user-static'."
+    else
+      ok "QEMU installed"
+    fi
+  fi
+
+  if [[ ! -e '/proc/sys/fs/binfmt_misc/qemu-aarch64' ]]; then
+    error 'QEMU not registered in binfmt_misc.'
+  fi
+  flags="$(grep 'flags:' /proc/sys/fs/binfmt_misc/qemu-aarch64 | \
+	   cut -d' ' -f2)"
+  if [[ "$(echo "$flags" | grep -c F)" == '0' ]]; then
+    error 'QEMU not registered in binfmt_misc with fix-binary (F) flag.'
+  else
+    ok "QEMU registered in binfmt_misc with flags $flags (F is required)."
+  fi
+
+  echo "Host looks good for docker buildx multi-architecture support".
+}
+
+set -e
+check_qemu_binfmt "$@"

--- a/doctor
+++ b/doctor
@@ -4,7 +4,7 @@
 #
 # This script checks if all software requirements are met in a Linux environment
 # in order to use 'docker buildx' to build multi-architecture images.
-# For more information see:
+# For more information see: 
 # https://nexus.eddiesinentropy.net/2020/01/12/Building-Multi-architecture-Docker-Images-With-Buildx/
 
 function error() {

--- a/run
+++ b/run
@@ -7,24 +7,24 @@ function buildx_11_buster { # [...docker buildx build flags]: builds multi-arch 
   docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
 }
 
-function buildx_15_bookworm { # [...docker buildx build flags]: builds multi-arch factalinc/postgres:15.1-bookworm image
-  docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:15.1-bookworm "$repo_root/15/bookworm" "$@"
+function buildx_15_bookworm { # [...docker buildx build flags]: builds multi-arch factalinc/postgres:15.2-bookworm image
+  docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:15.2-bookworm "$repo_root/15/bookworm" "$@"
 }
 
 function build_11_buster { # [...docker buildx build flags]: builds factalinc/postgres:11.16-buster image for only the currect arch
   docker buildx build --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
 }
 
-function build_15_bookworm { # [...docker buildx build flags]: builds factalinc/postgres:15.1-bookworm image for only the currect arch
-  docker buildx build --tag factalinc/postgres:15.1-bookworm "$repo_root/15/bookworm" "$@"
+function build_15_bookworm { # [...docker buildx build flags]: builds factalinc/postgres:15.2-bookworm image for only the currect arch
+  docker buildx build --tag factalinc/postgres:15.2-bookworm "$repo_root/15/bookworm" "$@"
 }
 
 function remove_11_buster { # [...docker image rm flags]: removes factalinc/postgres:11.16-buster image
   docker image rm --force factalinc/postgres:11.16-buster "$@"
 }
 
-function remove_15_bookworm { # [...docker image rm flags]: removes factalinc/postgres:15.1-bookworm image
-  docker image rm --force factalinc/postgres:15.1-bookworm "$@"
+function remove_15_bookworm { # [...docker image rm flags]: removes factalinc/postgres:15.2-bookworm image
+  docker image rm --force factalinc/postgres:15.2-bookworm "$@"
 }
 
 if [[ $# -eq 0 || "$1" == "help" ]]; then

--- a/run
+++ b/run
@@ -4,11 +4,11 @@ set -e -o pipefail
 repo_root="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 function buildx_11_buster { # [...docker buildx build flags]: builds multi-arch factalinc/postgres:11.16-buster image
-  docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
+  docker buildx build --platform linux/386,linux/arm64/v8,linux/amd64 --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
 }
 
 function buildx_15_bookworm { # [...docker buildx build flags]: builds multi-arch factalinc/postgres:15.2-bookworm image
-  docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:15.2-bookworm "$repo_root/15/bookworm" "$@"
+  docker buildx build --platform linux/386,linux/arm64/v8,linux/amd64 --tag factalinc/postgres:15.2-bookworm "$repo_root/15/bookworm" "$@"
 }
 
 function build_11_buster { # [...docker buildx build flags]: builds factalinc/postgres:11.16-buster image for only the currect arch

--- a/run
+++ b/run
@@ -4,15 +4,27 @@ set -e -o pipefail
 repo_root="$( cd "$(dirname "$0")" >/dev/null 2>&1 ; pwd -P )"
 
 function buildx_11_buster { # [...docker buildx build flags]: builds multi-arch factalinc/postgres:11.16-buster image
-  docker buildx build --platform linux/386,linux/arm64/v8,linux/amd64 --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
+  docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
+}
+
+function buildx_15_bookworm { # [...docker buildx build flags]: builds multi-arch factalinc/postgres:15.1-bookworm image
+  docker buildx build --platform linux/arm64/v8,linux/amd64 --tag factalinc/postgres:15.1-bookworm "$repo_root/15/bookworm" "$@"
 }
 
 function build_11_buster { # [...docker buildx build flags]: builds factalinc/postgres:11.16-buster image for only the currect arch
   docker buildx build --tag factalinc/postgres:11.16-buster "$repo_root/11/buster" "$@"
 }
 
+function build_15_bookworm { # [...docker buildx build flags]: builds factalinc/postgres:15.1-bookworm image for only the currect arch
+  docker buildx build --tag factalinc/postgres:15.1-bookworm "$repo_root/15/bookworm" "$@"
+}
+
 function remove_11_buster { # [...docker image rm flags]: removes factalinc/postgres:11.16-buster image
   docker image rm --force factalinc/postgres:11.16-buster "$@"
+}
+
+function remove_15_bookworm { # [...docker image rm flags]: removes factalinc/postgres:15.1-bookworm image
+  docker image rm --force factalinc/postgres:15.1-bookworm "$@"
 }
 
 if [[ $# -eq 0 || "$1" == "help" ]]; then


### PR DESCRIPTION
https://factal-inc.atlassian.net/browse/OPS-31

**Changes**
* Update run script to generate postgres 15 images
* Remove i386 targets from PG 11. No one is using these anymore.
* Add doctor script to assert pre-reqs for docker buildx

**Testing**
* Test the doctor script on OSX. I'm only able to test it on Linux (Ubuntu).

**Notes**
* I have already pushed these images to Docker Hub. The image is available as `factalinc/postgres:15.2-bookworm`. See: https://hub.docker.com/repository/docker/factalinc/postgres/general for details.
